### PR TITLE
(#15) Mention DuckDuckGo when sharing links on Twitter

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -51,8 +51,8 @@
     <string name="ShareSearch">Suche teilen</string>
     <string name="SharePage">Seite teilen</string>
     
-    <string name="ShareTrailingString">via DuckDuckGo für Android</string>
-    <string name="ShareTrailingTwitterString">via @duckduckgo für Android</string>
+    <string name="RegularShareFormat">%1$s via DuckDuckGo für Android</string>
+    <string name="TwitterShareFormat">%1$s via @duckduckgo für Android</string>
     
     <string name="Yes">Ja</string>
     <string name="No">Nein</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -51,8 +51,8 @@
     <string name="ShareSearch">Share Search</string>
     <string name="SharePage">Share Page</string>
     
-    <string name="ShareTrailingString">via DuckDuckGo for Android</string>
-    <string name="ShareTrailingTwitterString">via @duckduckgo for Android</string>
+    <string name="RegularShareFormat">%1$s via DuckDuckGo for Android</string>
+    <string name="TwitterShareFormat">%1$s via @duckduckgo for Android</string>
     
     <string name="Yes">Yes</string>
     <string name="No">No</string>

--- a/src/com/duckduckgo/mobile/android/util/Sharer.java
+++ b/src/com/duckduckgo/mobile/android/util/Sharer.java
@@ -26,7 +26,7 @@ public class Sharer {
 
 	public static void shareStory(Context context, String title, String url) {
 		String actionName = (String) context.getResources().getText(R.string.ShareStory);
-		Intent shareIntent = createTargetedShareIntent(context, formatShareText(title, url), title, actionName);
+		Intent shareIntent = createTargetedShareIntent(context, String.format("%s %s", title, url), title, actionName);
 		context.startActivity(Intent.createChooser(shareIntent, actionName));
 	}
 
@@ -40,7 +40,7 @@ public class Sharer {
 	
 	private static Intent createTargetedShareIntent(Context context, String text, String subject, String actionName) {
 		List<Intent> targetedShareIntents = new ArrayList<Intent>();
-		Intent shareIntent = createBasicShareIntent(text, subject);
+		Intent shareIntent = createBasicShareIntent(context, text, subject);
 		List<HashMap<String, String>> intentMetaInfo = new ArrayList<HashMap<String, String>>();
         List<ResolveInfo> resInfo = context.getPackageManager().queryIntentActivities(shareIntent, 0);
         
@@ -69,13 +69,9 @@ public class Sharer {
 	                
 	                if (packageName.contains("twitter")) {
 	                    targetedShareIntent.putExtra(Intent.EXTRA_TEXT, 
-	                    		formatShareText(text, (String)context.getResources().getText(R.string.ShareTrailingTwitterString)));
+	                    		String.format(context.getResources().getString(R.string.TwitterShareFormat), text));
 	                }
-	                else {
-	                	targetedShareIntent.putExtra(Intent.EXTRA_TEXT, 
-	                    		formatShareText(text, (String)context.getResources().getText(R.string.ShareTrailingString)));
-	                }
-
+	                
     				targetedShareIntent.setPackage(packageName);
     				targetedShareIntent.setClassName(metaInfo.get("packageName"), metaInfo.get("className"));
     				targetedShareIntents.add(targetedShareIntent);
@@ -90,17 +86,13 @@ public class Sharer {
         return shareIntent;
 	}
 	
-	private static Intent createBasicShareIntent(String text, String subject) {
+	private static Intent createBasicShareIntent(Context context, String text, String subject) {
 		Intent shareIntent = new Intent();
 		shareIntent.setAction(Intent.ACTION_SEND);
 		shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 		shareIntent.setType("text/plain");
-		shareIntent.putExtra(Intent.EXTRA_TEXT, text);
+		shareIntent.putExtra(Intent.EXTRA_TEXT, String.format(context.getResources().getString(R.string.RegularShareFormat), text));
 		shareIntent.putExtra(Intent.EXTRA_SUBJECT, subject);
 		return shareIntent;
-	}
-	
-	private static String formatShareText(String text, String shareText) {
-		return text + " " + shareText;
 	}
 }


### PR DESCRIPTION
When sharing a story, page or a search, display “via @duckduckgo for Android” instead of “via DuckDuckGo for Android” for any app that contains “twitter” in its package name.

Based on http://stackoverflow.com/a/8550043 and https://gist.github.com/mediavrog/5625602.
