### PR TITLE
Make it possible to save a picture

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -256,6 +256,7 @@
     <string name="action_forward">Forward</string>
     <string name="action_close">Close</string>
     <string name="remove">Remove</string>
+    <string name="save_image_context_menu_action">Save Image</string>
 
 
 

--- a/src/com/duckduckgo/mobile/android/fragment/WebFragment.java
+++ b/src/com/duckduckgo/mobile/android/fragment/WebFragment.java
@@ -1,16 +1,20 @@
 package com.duckduckgo.mobile.android.fragment;
 
-import android.app.Activity;
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.view.menu.MenuBuilder;
 import android.util.Log;
+import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -18,6 +22,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.DownloadListener;
+import android.webkit.WebView;
 
 import com.duckduckgo.mobile.android.DDGApplication;
 import com.duckduckgo.mobile.android.R;
@@ -79,6 +84,8 @@ public class WebFragment extends Fragment {
 	public static final String TAG = "web_fragment";
 	public static final String URL = "url";
     public static final String SESSION_TYPE = "session_type";
+	private static final int ITEM_ID_SAVE_IMAGE = 0;
+	private static final int REQUEST_WRITE_EXTERNAL_STORAGE = 0;
 
     private Context context = null;
 
@@ -147,9 +154,65 @@ public class WebFragment extends Fragment {
 			mainWebView.restoreState(savedInstanceState);
 			urlType = URLTYPE.getByCode(savedInstanceState.getInt("url_type"));
 		}
+		if (isDownloadImagesSupported()) {
+			registerForContextMenu(mainWebView);
+		}
 	}
 
-    @Override
+	@Override
+	public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
+		super.onCreateContextMenu(menu, v, menuInfo);
+		WebView.HitTestResult hitTestResult = mainWebView.getHitTestResult();
+		if (isDownloadImagesSupported() && isImage(hitTestResult)) {
+			menu.setHeaderTitle(hitTestResult.getExtra());
+			menu.add(0, ITEM_ID_SAVE_IMAGE, 0, R.string.save_image_context_menu_action);
+		}
+	}
+
+	@Override
+	public boolean onContextItemSelected(MenuItem item) {
+		if (item.getItemId() == ITEM_ID_SAVE_IMAGE && isDownloadImagesSupported()) {
+			if (hasWriteExternalStoragePermission()) {
+				scheduleImageDownload();
+			} else {
+				requestPermissions(new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE },
+						REQUEST_WRITE_EXTERNAL_STORAGE);
+			}
+			return true;
+		}
+		return super.onContextItemSelected(item);
+	}
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+		if (requestCode == REQUEST_WRITE_EXTERNAL_STORAGE && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+			scheduleImageDownload();
+		} else {
+			super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+		}
+	}
+
+	private void scheduleImageDownload() {
+		String imageUrl = mainWebView.getHitTestResult().getExtra();
+		contentDownloader.downloadImage(imageUrl);
+	}
+
+	private boolean hasWriteExternalStoragePermission() {
+		int permission = ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE);
+		return permission == PackageManager.PERMISSION_GRANTED;
+	}
+
+	private boolean isImage(WebView.HitTestResult hitTestResult) {
+		int type = hitTestResult.getType();
+		return type == WebView.HitTestResult.IMAGE_TYPE || type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE;
+	}
+
+	private boolean isDownloadImagesSupported() {
+		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD
+				&& contentDownloader.isDownloadManagerEnabled();
+	}
+
+	@Override
     public void onStart() {
         super.onStart();
         DDGControlVar.mDuckDuckGoContainer.torIntegration.prepareTorSettings();


### PR DESCRIPTION
Hey @fgei, @nilnilnil 

I went through DDG's Google Play reviews and found some comments raising lack of saving pictures ability. As I had some spare time this evening I decided to give it a shot. And I got stuck as some technical/product decisions have to be made.

I commited code below based on the following assumptions:
1. As a user I'd prefer to keep my downloaded images in publicly accessible directory, so I can access it later on using some 3rd party gallery app or edit them. This requires `WRITE_EXTERNAL_STORAGE` permission, which was already defined in `AndroidManifest.xml` but still can be disabled by user if she's running 6.0 or newer, so I had to code some runtime-permissions-related stuff. I'm open to whatever else though.
2. I found "save by a long-press" solution the most recognized and clear way of saving images as most popular browers do the same.

![screenshot_20160314-001834](https://cloud.githubusercontent.com/assets/336158/13732088/7c6cf0f8-e97a-11e5-8109-5b6176eb163b.png)
1. I haven't implemented Froyo support yet as I am not sure if it's still needed and I don't have any reliable way of testing it. However, this code doesn't break any existing behavior for 2.2 users (anyone?).
2. Some more low-level stuff needs to be discussed perhaps - like a filename of downloaded picture. Currently it's an UUID, I think it's good enough.

I'm still not sure how to approach `DownloadReceiver` implementation. It gets called every time download finishes (no matter if it's image download, or file download) and opens a file. This happens even if download takes much time, and user is already working with some other app - suddenly DDG tries to open just downloaded file. Considering the fact that these downloads emit notifications (both in-progress and completed) - do we still need to open a file automatically?

Thoughts?
