### PR TITLE
Bump min sdk to 16 and move defaultConfig to build.gradle

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.duckduckgo.mobile.android"
-    android:installLocation="auto"
-    android:versionCode="79"
-    android:versionName="3.0.17">
+    android:installLocation="auto">
 
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="23" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
@@ -42,30 +39,6 @@
             <meta-data
                 android:name="com.android.systemui.action_assist_icon"
                 android:resource="@drawable/icon"/>
-            <!--
-            <intent-filter>
-                <action android:name="android.intent.action.ASSIST"/>
-                <action android:name="android.intent.action.SEARCH" />
-                <action android:name="android.intent.action.SEARCH_LONG_PRESS" />
-                <category android:name="android.intent.category.DEFAULT" />\
-            </intent-filter>-->
-<!--
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.WEB_SEARCH" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-            </intent-filter>
--->
             <meta-data android:name="android.app.searchable"
                 android:resource="@xml/searchable" />
         </activity>
@@ -98,14 +71,7 @@
 		        <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
 		    </intent-filter>
 		</receiver>
-		
-		<activity android:name="info.guardianproject.onionkit.ui.CertDisplayActivity"
-            android:configChanges="locale|orientation"
-            android:theme="@android:style/Theme.Dialog"
-            android:taskAffinity="" />
-<!--
-        <service android:name="com.duckduckgo.mobile.android.subscribers.MainSubscriber" />
-	-->
+
     </application>
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,14 @@ android {
   compileSdkVersion 23
   buildToolsVersion "23.0.3"
 
+  defaultConfig {
+    applicationId "com.duckduckgo.mobile.android"
+    minSdkVersion 16
+    targetSdkVersion 23
+    versionCode 79
+    versionName "3.0.17"
+  }
+
   repositories {
     mavenCentral()
   }


### PR DESCRIPTION
Bump min sdk to 16 and move defaultConfig data from the manifest to build gradle file.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, though reviewer and all items in bold are required.
-->

Reviewer: @subsymbolic 
Asana: https://app.asana.com/0/19626896268257/333077212749536

**Description**: Bump min sdk to 16 before merging new PR and to prepare a new release



###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications (Database connections, Grafana stats, CPU)